### PR TITLE
z-image support (highly experimental)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && \
 COPY requirements_docker.txt requirements_versions.txt /tmp/
 RUN pip install --no-cache-dir -r /tmp/requirements_docker.txt -r /tmp/requirements_versions.txt && \
 	rm -f /tmp/requirements_docker.txt /tmp/requirements_versions.txt
-RUN pip install --no-cache-dir xformers==0.0.23 --no-dependencies
+RUN pip install --no-cache-dir xformers==0.0.29.post2 --no-dependencies
 RUN curl -fsL -o /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2 https://cdn-media.huggingface.co/frpc-gradio-0.2/frpc_linux_amd64 && \
 	chmod +x /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && \
 COPY requirements_docker.txt requirements_versions.txt /tmp/
 RUN pip install --no-cache-dir -r /tmp/requirements_docker.txt -r /tmp/requirements_versions.txt && \
 	rm -f /tmp/requirements_docker.txt /tmp/requirements_versions.txt
-RUN pip install --no-cache-dir xformers==0.0.29.post2 --no-dependencies
+RUN pip install --no-cache-dir xformers==0.0.33.post1 --no-dependencies
 RUN curl -fsL -o /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2 https://cdn-media.huggingface.co/frpc-gradio-0.2/frpc_linux_amd64 && \
 	chmod +x /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && \
 COPY requirements_docker.txt requirements_versions.txt /tmp/
 RUN pip install --no-cache-dir -r /tmp/requirements_docker.txt -r /tmp/requirements_versions.txt && \
 	rm -f /tmp/requirements_docker.txt /tmp/requirements_versions.txt
-RUN pip install --no-cache-dir xformers==0.0.33.post1 --no-dependencies
+RUN pip install --no-cache-dir xformers==0.0.33.post2 --no-dependencies
 RUN curl -fsL -o /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2 https://cdn-media.huggingface.co/frpc-gradio-0.2/frpc_linux_amd64 && \
 	chmod +x /usr/local/lib/python3.10/dist-packages/gradio/frpc_linux_amd64_v0.2
 

--- a/extras/expansion.py
+++ b/extras/expansion.py
@@ -34,8 +34,20 @@ def remove_pattern(x, pattern):
     return x
 
 
+class DisabledFooocusExpansion:
+    def __init__(self, reason: str):
+        self.available = False
+        self.reason = safe_str(reason)
+        self.patcher = None
+        print(f'Fooocus Expansion disabled: {self.reason}')
+
+    def __call__(self, prompt, seed):
+        return ''
+
+
 class FooocusExpansion:
     def __init__(self):
+        self.available = True
         self.tokenizer = AutoTokenizer.from_pretrained(path_fooocus_expansion)
 
         positive_words = open(os.path.join(path_fooocus_expansion, 'positive.txt'),

--- a/launch.py
+++ b/launch.py
@@ -393,6 +393,7 @@ def prepare_environment():
 
     zimage_default_env = {
         # Tuned defaults for stable, fast Z-Image runs on ~12GB VRAM cards.
+        "FOOOCUS_ZIMAGE_ALT_PATH": "1",
         "FOOOCUS_ZIMAGE_ATTN_BACKEND": "auto",
         "FOOOCUS_ZIMAGE_UNLOAD_STANDARD_MODELS": "1",
         "FOOOCUS_ZIMAGE_RESERVE_VRAM_GB": "2.2",

--- a/launch.py
+++ b/launch.py
@@ -399,6 +399,7 @@ def prepare_environment():
         "FOOOCUS_ZIMAGE_PERF_PROFILE": "speed",
         "FOOOCUS_ZIMAGE_ALLOW_QUALITY_FALLBACK": "0",
         "FOOOCUS_ZIMAGE_COMPUTE_DTYPE": "auto",
+        "FOOOCUS_ZIMAGE_PREWARM": "1",
     }
     applied_defaults = []
     for key, value in zimage_default_env.items():

--- a/launch.py
+++ b/launch.py
@@ -399,7 +399,6 @@ def prepare_environment():
         "FOOOCUS_ZIMAGE_PERF_PROFILE": "speed",
         "FOOOCUS_ZIMAGE_ALLOW_QUALITY_FALLBACK": "0",
         "FOOOCUS_ZIMAGE_COMPUTE_DTYPE": "auto",
-        "FOOOCUS_ZIMAGE_PREWARM": "1",
     }
     applied_defaults = []
     for key, value in zimage_default_env.items():

--- a/launch.py
+++ b/launch.py
@@ -54,6 +54,8 @@ def _recommended_xformers_for_torch() -> str | None:
         "2.5.1": "xformers==0.0.29.post1",
         "2.6.0": "xformers==0.0.29.post2",
         "2.9.0": "xformers==0.0.33.post1",
+        "2.9.1": "xformers==0.0.33.post1",
+        "2.10.0": "xformers==0.0.34",
     }
     return mapping.get(torch_version, None)
 
@@ -65,9 +67,9 @@ def _version_from_pin(spec: str) -> str | None:
 
 
 def prepare_environment():
-    torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu126")
+    torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu128")
     torch_command = os.environ.get('TORCH_COMMAND',
-                                   f"pip install torch==2.9.0 torchvision==0.24.0 --extra-index-url {torch_index_url}")
+                                   f"pip install torch==2.9.1 torchvision==0.24.1 --extra-index-url {torch_index_url}")
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
 
     print(f"Python {sys.version}")
@@ -77,10 +79,10 @@ def prepare_environment():
         REINSTALL_ALL
         or not is_installed("torch")
         or not is_installed("torchvision")
-        or not torch_stack_is_compatible("2.9.0")
+        or not torch_stack_is_compatible("2.9.1")
     )
     if need_torch_stack_install:
-        print("Installing/upgrading torch stack (requires torch>=2.9 for this safe branch xformers profile).")
+        print("Installing/upgrading torch stack (requires torch>=2.9.1 for this safe branch profile).")
         run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch", live=True)
 
     if TRY_INSTALL_XFORMERS:

--- a/launch.py
+++ b/launch.py
@@ -53,6 +53,7 @@ def _recommended_xformers_for_torch() -> str | None:
         "2.5.0": "xformers==0.0.28.post2",
         "2.5.1": "xformers==0.0.29.post1",
         "2.6.0": "xformers==0.0.29.post2",
+        "2.9.0": "xformers==0.0.33.post1",
     }
     return mapping.get(torch_version, None)
 
@@ -64,9 +65,9 @@ def _version_from_pin(spec: str) -> str | None:
 
 
 def prepare_environment():
-    torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu124")
+    torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu126")
     torch_command = os.environ.get('TORCH_COMMAND',
-                                   f"pip install torch==2.6.0 torchvision==0.21.0 --extra-index-url {torch_index_url}")
+                                   f"pip install torch==2.9.0 torchvision==0.24.0 --extra-index-url {torch_index_url}")
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
 
     print(f"Python {sys.version}")
@@ -76,10 +77,10 @@ def prepare_environment():
         REINSTALL_ALL
         or not is_installed("torch")
         or not is_installed("torchvision")
-        or not torch_stack_is_compatible("2.6.0")
+        or not torch_stack_is_compatible("2.9.0")
     )
     if need_torch_stack_install:
-        print("Installing/upgrading torch stack (requires torch>=2.6 for current transformers security policy).")
+        print("Installing/upgrading torch stack (requires torch>=2.9 for this safe branch xformers profile).")
         run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch", live=True)
 
     if TRY_INSTALL_XFORMERS:

--- a/launch.py
+++ b/launch.py
@@ -64,9 +64,9 @@ def _version_from_pin(spec: str) -> str | None:
 
 
 def prepare_environment():
-    torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu121")
+    torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu124")
     torch_command = os.environ.get('TORCH_COMMAND',
-                                   f"pip install torch==2.5.1 torchvision==0.20.1 --extra-index-url {torch_index_url}")
+                                   f"pip install torch==2.6.0 torchvision==0.21.0 --extra-index-url {torch_index_url}")
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
 
     print(f"Python {sys.version}")
@@ -76,10 +76,10 @@ def prepare_environment():
         REINSTALL_ALL
         or not is_installed("torch")
         or not is_installed("torchvision")
-        or not torch_stack_is_compatible("2.2.0")
+        or not torch_stack_is_compatible("2.6.0")
     )
     if need_torch_stack_install:
-        print("Installing/upgrading torch stack (requires torch>=2.2 for current transformers).")
+        print("Installing/upgrading torch stack (requires torch>=2.6 for current transformers security policy).")
         run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch", live=True)
 
     if TRY_INSTALL_XFORMERS:

--- a/launch.py
+++ b/launch.py
@@ -394,6 +394,7 @@ def prepare_environment():
     zimage_default_env = {
         # Tuned defaults for stable, fast Z-Image runs on ~12GB VRAM cards.
         "FOOOCUS_ZIMAGE_ALT_PATH": "1",
+        "FOOOCUS_ZIMAGE_ALT_FORCE_FULL_GPU": "1",
         "FOOOCUS_ZIMAGE_ATTN_BACKEND": "auto",
         "FOOOCUS_ZIMAGE_UNLOAD_STANDARD_MODELS": "1",
         "FOOOCUS_ZIMAGE_RESERVE_VRAM_GB": "2.2",

--- a/launch.py
+++ b/launch.py
@@ -398,6 +398,7 @@ def prepare_environment():
         "FOOOCUS_ZIMAGE_RESERVE_VRAM_GB": "2.2",
         "FOOOCUS_ZIMAGE_PERF_PROFILE": "speed",
         "FOOOCUS_ZIMAGE_ALLOW_QUALITY_FALLBACK": "0",
+        "FOOOCUS_ZIMAGE_COMPUTE_DTYPE": "auto",
     }
     applied_defaults = []
     for key, value in zimage_default_env.items():

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -926,17 +926,6 @@ def worker():
             print(f'[Z-Image POC] Warning: failed to clear standard prompt cache: {e}')
 
         try:
-            # Drop references to currently active non-Z-Image pipeline objects.
-            pipeline.final_unet = None
-            pipeline.final_clip = None
-            pipeline.final_vae = None
-            pipeline.final_refiner_unet = None
-            pipeline.final_refiner_vae = None
-            pipeline.final_expansion = None
-        except Exception as e:
-            print(f'[Z-Image POC] Warning: failed to clear standard pipeline refs: {e}')
-
-        try:
             ldm_patched.modules.model_management.unload_all_models()
             ldm_patched.modules.model_management.soft_empty_cache(force=True)
             print('[Z-Image POC] Standard model unload complete.')

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -958,6 +958,7 @@ def worker():
 
         print(f'[Z-Image POC] Source: {source_kind} @ {source_path}')
         print(f"[Z-Image POC] Overrides: text_encoder={async_task.zit_text_encoder}, vae={async_task.zit_vae}")
+        print(f"[Z-Image POC] Active backend: {modules.zimage_poc.zimage_active_backend_name()}")
 
         try:
             modules.zimage_poc.maybe_cleanup_for_model_change(source_kind, source_path)

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -882,17 +882,18 @@ def worker():
             print('Refiner disabled in Z-Image Turbo mode.')
             async_task.refiner_model_name = 'None'
 
+        # Match Forge Z-Image Turbo ("zit") defaults.
         async_task.sampler_name = 'euler'
-        async_task.scheduler_name = 'sgm_uniform'
+        async_task.scheduler_name = 'beta' if 'beta' in flags.scheduler_list else 'sgm_uniform'
         async_task.cfg_scale = 1.0
-        async_task.adaptive_cfg = 1.0
+        # In Forge this control is displayed as "Shift" for Z-Image Turbo (default 9.0).
+        async_task.adaptive_cfg = 9.0
         async_task.sharpness = 0.0
         async_task.refiner_switch = 1.0
         async_task.adm_scaler_positive = 1.0
         async_task.adm_scaler_negative = 1.0
         async_task.adm_scaler_end = 0.0
-        if async_task.steps > 8:
-            async_task.steps = 4
+        async_task.steps = 9
 
     def run_zimage_poc(async_task, width, height, current_progress):
         source_kind, source_path, flavor = modules.zimage_poc.resolve_zimage_source(

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -957,6 +957,7 @@ def worker():
                     steps=async_task.steps,
                     guidance_scale=float(async_task.cfg_scale),
                     seed=task_seed,
+                    shift=float(async_task.adaptive_cfg),
                 )
                 np_image = np.array(pil_image)
             except ModuleNotFoundError as e:

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -68,6 +68,8 @@ class AsyncTask:
         self.sampler_name = args.pop()
         self.scheduler_name = args.pop()
         self.vae_name = args.pop()
+        self.zit_text_encoder = args.pop()
+        self.zit_vae = args.pop()
         self.overwrite_step = args.pop()
         self.overwrite_switch = args.pop()
         self.overwrite_width = args.pop()
@@ -895,11 +897,11 @@ def worker():
         async_task.scheduler_name = 'beta' if 'beta' in flags.scheduler_list else 'sgm_uniform'
         async_task.cfg_scale = 1.0
         # Shift control for Z-Image Turbo.
-        # ComfyUI Turbo workflows commonly run shift=3.0; allow override via env.
+        # Neo preset defaults to shift=9.0; allow override via env.
         try:
-            async_task.adaptive_cfg = float(os.environ.get('FOOOCUS_ZIMAGE_TURBO_SHIFT', '3.0'))
+            async_task.adaptive_cfg = float(os.environ.get('FOOOCUS_ZIMAGE_TURBO_SHIFT', '9.0'))
         except Exception:
-            async_task.adaptive_cfg = 3.0
+            async_task.adaptive_cfg = 9.0
         async_task.sharpness = 0.0
         async_task.refiner_switch = 1.0
         async_task.adm_scaler_positive = 1.0
@@ -970,6 +972,8 @@ def worker():
                     guidance_scale=float(async_task.cfg_scale),
                     seed=task_seed,
                     shift=float(async_task.adaptive_cfg),
+                    text_encoder_override=async_task.zit_text_encoder,
+                    vae_override=async_task.zit_vae,
                 )
                 np_image = np.array(pil_image)
             except ModuleNotFoundError as e:

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -752,6 +752,14 @@ def worker():
                 log_negative_prompt='\n'.join([task_negative_prompt] + task_extra_negative_prompts),
                 styles=task_styles
             ))
+        expansion_available = (
+            pipeline.final_expansion is not None and getattr(pipeline.final_expansion, "available", True)
+        )
+        if use_expansion and not expansion_available:
+            reason = getattr(pipeline.final_expansion, "reason", "unavailable")
+            print(f"[Prompt Expansion] Disabled at runtime: {reason}")
+            use_expansion = False
+
         if use_expansion:
             if advance_progress:
                 current_progress += 1

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -902,6 +902,9 @@ def worker():
         )
         if source_path is None:
             progressbar(async_task, 100, f'Z-Image model source not found: {async_task.base_model_name}')
+            print('[Z-Image POC] Checked checkpoint folders:')
+            for p in modules.config.paths_checkpoints:
+                print(f'  - {p}')
             return
 
         print(f'[Z-Image POC] Source: {source_kind} @ {source_path}')

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -923,6 +923,7 @@ def worker():
             return
 
         print(f'[Z-Image POC] Source: {source_kind} @ {source_path}')
+        print(f"[Z-Image POC] Overrides: text_encoder={async_task.zit_text_encoder}, vae={async_task.zit_vae}")
 
         unsupported = []
         if async_task.input_image_checkbox:

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -955,7 +955,8 @@ def worker():
                 np_image = np.array(pil_image)
             except ModuleNotFoundError as e:
                 progressbar(async_task, 100, f'Z-Image POC requires missing dependency: {e}')
-                print('[Z-Image POC] Install required dependencies (diffusers/safetensors/torch).')
+                print('[Z-Image POC] Install required dependencies with:')
+                print('  python -m pip install "diffusers==0.30.3" "safetensors>=0.4.3"')
                 return
             except Exception as e:
                 progressbar(async_task, 100, f'Z-Image generation failed: {e}')

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -882,8 +882,7 @@ def worker():
         async_task.adm_scaler_end = 0.0
         return current_progress
 
-    def apply_zimage_turbo_defaults(async_task):
-        flavor = modules.zimage_poc.detect_zimage_flavor(async_task.base_model_name)
+    def apply_zimage_turbo_defaults(async_task, flavor: str):
         if flavor != 'turbo':
             return
 
@@ -960,6 +959,11 @@ def worker():
         print(f'[Z-Image POC] Source: {source_kind} @ {source_path}')
         print(f"[Z-Image POC] Overrides: text_encoder={async_task.zit_text_encoder}, vae={async_task.zit_vae}")
 
+        try:
+            modules.zimage_poc.maybe_cleanup_for_model_change(source_kind, source_path)
+        except Exception as e:
+            print(f'[Z-Image POC] Warning: model-change cleanup check failed: {e}')
+
         unsupported = []
         if async_task.input_image_checkbox:
             unsupported.append('image input')
@@ -971,7 +975,7 @@ def worker():
             print(f"[Z-Image POC] Ignoring unsupported features: {', '.join(unsupported)}")
 
         unloaded_standard_models = maybe_unload_standard_models_for_zimage()
-        apply_zimage_turbo_defaults(async_task)
+        apply_zimage_turbo_defaults(async_task, flavor)
         current_progress = max(current_progress, 2)
         progressbar(async_task, current_progress, 'Running Z-Image POC generation ...')
 

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -898,7 +898,7 @@ def worker():
         source_kind, source_path, flavor = modules.zimage_poc.resolve_zimage_source(
             async_task.base_model_name,
             modules.config.paths_checkpoints,
-            auto_download_if_missing=True,
+            auto_download_if_missing=False,
         )
         if source_path is None:
             progressbar(async_task, 100, f'Z-Image model source not found: {async_task.base_model_name}')

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -185,6 +185,7 @@ def worker():
     import modules.core as core
     import modules.flags as flags
     import modules.patch
+    import modules.zimage_poc
     import ldm_patched.modules.model_management
     import extras.preprocessors as preprocessors
     import modules.inpaint_worker as inpaint_worker
@@ -871,6 +872,110 @@ def worker():
         async_task.adm_scaler_end = 0.0
         return current_progress
 
+    def apply_zimage_turbo_defaults(async_task):
+        flavor = modules.zimage_poc.detect_zimage_flavor(async_task.base_model_name)
+        if flavor != 'turbo':
+            return
+
+        print('Enter Z-Image Turbo mode.')
+        if async_task.refiner_model_name != 'None':
+            print('Refiner disabled in Z-Image Turbo mode.')
+            async_task.refiner_model_name = 'None'
+
+        async_task.sampler_name = 'euler'
+        async_task.scheduler_name = 'sgm_uniform'
+        async_task.cfg_scale = 1.0
+        async_task.adaptive_cfg = 1.0
+        async_task.sharpness = 0.0
+        async_task.refiner_switch = 1.0
+        async_task.adm_scaler_positive = 1.0
+        async_task.adm_scaler_negative = 1.0
+        async_task.adm_scaler_end = 0.0
+        if async_task.steps > 8:
+            async_task.steps = 4
+
+    def run_zimage_poc(async_task, width, height, current_progress):
+        source_kind, source_path, flavor = modules.zimage_poc.resolve_zimage_source(
+            async_task.base_model_name,
+            modules.config.paths_checkpoints,
+        )
+        if source_path is None:
+            progressbar(async_task, 100, f'Z-Image model source not found or unsupported: {async_task.base_model_name}')
+            return
+
+        print(f'[Z-Image POC] Source: {source_kind} @ {source_path}')
+
+        unsupported = []
+        if async_task.input_image_checkbox:
+            unsupported.append('image input')
+        if async_task.enhance_checkbox:
+            unsupported.append('enhance')
+        if len(async_task.loras) > 0:
+            unsupported.append('LoRAs')
+        if unsupported:
+            print(f"[Z-Image POC] Ignoring unsupported features: {', '.join(unsupported)}")
+
+        apply_zimage_turbo_defaults(async_task)
+        current_progress = max(current_progress, 2)
+        progressbar(async_task, current_progress, 'Running Z-Image POC generation ...')
+
+        for i in range(async_task.image_number):
+            if async_task.last_stop is not False:
+                break
+
+            if async_task.disable_seed_increment:
+                task_seed = async_task.seed % (constants.MAX_SEED + 1)
+            else:
+                task_seed = (async_task.seed + i) % (constants.MAX_SEED + 1)
+
+            task_rng = random.Random(task_seed)
+            task_prompt = apply_dynamic_prompts(
+                apply_wildcards(async_task.prompt, task_rng, i, async_task.read_wildcards_in_order),
+                task_rng,
+            )
+            task_negative_prompt = apply_dynamic_prompts(
+                apply_wildcards(async_task.negative_prompt, task_rng, i, async_task.read_wildcards_in_order),
+                task_rng,
+            )
+
+            progressbar(async_task, current_progress, f'Generating Z-Image {i + 1}/{async_task.image_number} ...')
+            try:
+                pil_image = modules.zimage_poc.generate_zimage(
+                    source_kind=source_kind,
+                    source_path=source_path,
+                    flavor=flavor,
+                    prompt=task_prompt,
+                    negative_prompt=task_negative_prompt,
+                    width=width,
+                    height=height,
+                    steps=async_task.steps,
+                    guidance_scale=float(async_task.cfg_scale),
+                    seed=task_seed,
+                )
+                np_image = np.array(pil_image)
+            except ModuleNotFoundError as e:
+                progressbar(async_task, 100, f'Z-Image POC requires missing dependency: {e}')
+                print('[Z-Image POC] Install required dependencies (diffusers/safetensors/torch).')
+                return
+            except Exception as e:
+                progressbar(async_task, 100, f'Z-Image generation failed: {e}')
+                print(f'[Z-Image POC] Generation failed: {e}')
+                return
+
+            task = dict(
+                task_seed=task_seed,
+                log_positive_prompt=task_prompt,
+                log_negative_prompt=task_negative_prompt,
+                expansion='',
+                styles=[],
+                positive=[task_prompt],
+                negative=[task_negative_prompt],
+            )
+            progress = int((i + 1) * 100 / float(max(async_task.image_number, 1)))
+            img_paths = save_and_log(async_task, height, [np_image], task, False, width, [], persist_image=True)
+            yield_result(async_task, img_paths, progress, async_task.black_out_nsfw, False,
+                         do_not_show_finished_images=async_task.disable_intermediate_results)
+
     def apply_image_input(async_task, base_model_additional_loras, clip_vision_path, controlnet_canny_path,
                           controlnet_cpds_path, goals, inpaint_head_model_path, inpaint_image, inpaint_mask,
                           inpaint_parameterized,  ip_adapter_face_path, ip_adapter_path, ip_negative_path,
@@ -1133,6 +1238,12 @@ def worker():
 
         width, height = async_task.aspect_ratios_selection.replace('×', ' ').split(' ')[:2]
         width, height = int(width), int(height)
+
+        if modules.zimage_poc.should_use_zimage_checkpoint(async_task.base_model_name, modules.config.paths_checkpoints):
+            print('[Parameters] Z-Image checkpoint detected, using POC path.')
+            run_zimage_poc(async_task, width, height, current_progress)
+            stop_processing(async_task, preparation_start_time)
+            return
 
         skip_prompt_processing = False
 

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -956,7 +956,7 @@ def worker():
             except ModuleNotFoundError as e:
                 progressbar(async_task, 100, f'Z-Image POC requires missing dependency: {e}')
                 print('[Z-Image POC] Install required dependencies with:')
-                print('  python -m pip install "diffusers==0.30.3" "safetensors>=0.4.3"')
+                print('  python -m pip install -r requirements_versions.txt')
                 return
             except Exception as e:
                 progressbar(async_task, 100, f'Z-Image generation failed: {e}')

--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -886,8 +886,12 @@ def worker():
         async_task.sampler_name = 'euler'
         async_task.scheduler_name = 'beta' if 'beta' in flags.scheduler_list else 'sgm_uniform'
         async_task.cfg_scale = 1.0
-        # In Forge this control is displayed as "Shift" for Z-Image Turbo (default 9.0).
-        async_task.adaptive_cfg = 9.0
+        # Shift control for Z-Image Turbo.
+        # ComfyUI Turbo workflows commonly run shift=3.0; allow override via env.
+        try:
+            async_task.adaptive_cfg = float(os.environ.get('FOOOCUS_ZIMAGE_TURBO_SHIFT', '3.0'))
+        except Exception:
+            async_task.adaptive_cfg = 3.0
         async_task.sharpness = 0.0
         async_task.refiner_switch = 1.0
         async_task.adm_scaler_positive = 1.0

--- a/modules/config.py
+++ b/modules/config.py
@@ -7,6 +7,7 @@ import args_manager
 import tempfile
 import modules.flags
 import modules.sdxl_styles
+import modules.zimage_poc
 
 from modules.model_loader import load_file_from_url
 from modules.extra_utils import makedirs_with_log, get_files_from_folder, try_eval_env_var
@@ -830,6 +831,8 @@ def get_model_filenames(folder_paths, extensions=None, name_filter=None):
 def update_files():
     global model_filenames, lora_filenames, vae_filenames, wildcard_filenames, available_presets
     model_filenames = get_model_filenames(paths_checkpoints)
+    model_filenames += modules.zimage_poc.list_zimage_model_entries(paths_checkpoints)
+    model_filenames = sorted(set(model_filenames), key=str.casefold)
     lora_filenames = get_model_filenames(paths_loras)
     vae_filenames = get_model_filenames(path_vae)
     wildcard_filenames = get_files_from_folder(path_wildcards, ['.txt'])

--- a/modules/default_pipeline.py
+++ b/modules/default_pipeline.py
@@ -215,7 +215,10 @@ def set_clip_skip(clip_skip: int):
 @torch.no_grad()
 @torch.inference_mode()
 def clear_all_caches():
-    final_clip.fcs_cond_cache = {}
+    if final_clip is None:
+        return
+    if hasattr(final_clip, "fcs_cond_cache"):
+        final_clip.fcs_cond_cache = {}
 
 
 @torch.no_grad()
@@ -224,6 +227,8 @@ def prepare_text_encoder(async_call=True):
     if async_call:
         # TODO: make sure that this is always called in an async way so that users cannot feel it.
         pass
+    if final_clip is None:
+        return
     assert_model_integrity()
     patchers = [final_clip.patcher]
     if final_expansion is not None and getattr(final_expansion, "patcher", None) is not None:

--- a/modules/util.py
+++ b/modules/util.py
@@ -377,6 +377,8 @@ def get_file_from_folder_list(name, folders):
         filename = os.path.abspath(os.path.realpath(os.path.join(folder, name)))
         if os.path.isfile(filename):
             return filename
+        if os.path.isdir(filename):
+            return filename
 
     return os.path.abspath(os.path.realpath(os.path.join(folders[0], name)))
 

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -187,8 +187,11 @@ def resolve_zimage_source(name: str, checkpoint_folders: list[str], auto_downloa
     if resolved is not None:
         if os.path.isdir(resolved) and is_zimage_model_directory(resolved):
             return "directory", resolved, flavor
-        if os.path.isfile(resolved) and _is_likely_zimage_safetensors(resolved):
-            return "single_file", resolved, flavor
+        if os.path.isfile(resolved):
+            # Trust explicit user selection by filename pattern even when key fingerprint
+            # is inconclusive (common with repacked/quantized AIO checkpoints).
+            if _is_likely_zimage_safetensors(resolved) or is_zimage_checkpoint_name(os.path.basename(resolved)):
+                return "single_file", resolved, flavor
 
     return None, None, flavor
 

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -369,9 +369,9 @@ def _component_weight_files(component_dir: str) -> list[str]:
     return sorted(files, key=str.casefold)
 
 
-def list_zimage_component_choices(component_name: str, checkpoint_folders: list[str]) -> list[tuple[str, str]]:
+def _zimage_component_choice_pairs(component_name: str, checkpoint_folders: list[str]) -> list[tuple[str, str]]:
     entries = list_zimage_component_entries(component_name, checkpoint_folders)
-    choices = []
+    pairs = []
     label_counts = {}
     for entry in entries:
         rel = _human_component_path(entry, checkpoint_folders)
@@ -389,8 +389,12 @@ def list_zimage_component_choices(component_name: str, checkpoint_folders: list[
             label = f"{label} ({label_counts[label]})"
         else:
             label_counts[label] = 1
-        choices.append((label, os.path.abspath(entry)))
-    return choices
+        pairs.append((label, os.path.abspath(entry)))
+    return pairs
+
+
+def list_zimage_component_choices(component_name: str, checkpoint_folders: list[str]) -> list[str]:
+    return [label for label, _ in _zimage_component_choice_pairs(component_name, checkpoint_folders)]
 
 
 def resolve_zimage_component_path(
@@ -404,6 +408,10 @@ def resolve_zimage_component_path(
 
     if os.path.isabs(selected):
         return os.path.abspath(selected) if _is_valid_component_dir(selected, component_name) else None
+
+    for label, path in _zimage_component_choice_pairs(component_name, checkpoint_folders):
+        if selected == label:
+            return path
 
     for candidate in list_zimage_component_entries(component_name, checkpoint_folders):
         if candidate == selected:

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -4153,7 +4153,7 @@ def generate_zimage(
         flavor=flavor,
         prewarm_width=width,
         prewarm_height=height,
-        prewarm_max_sequence_length=max_sequence_length,
+        prewarm_max_sequence_length=min(max_sequence_length, 128 if flavor == "turbo" else 192),
     )
 
     if generator_device == "cuda":

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -102,6 +102,20 @@ def _resolve_named_path(name: str, checkpoint_folders: list[str]) -> Optional[st
         if os.path.exists(candidate):
             return candidate
 
+    # Fallback: match by basename anywhere inside configured checkpoint folders.
+    target = os.path.basename(name).casefold()
+    for folder in checkpoint_folders:
+        if not os.path.isdir(folder):
+            continue
+        for root, _, files in os.walk(folder, topdown=True):
+            for file_name in files:
+                if file_name.casefold() == target:
+                    return os.path.abspath(os.path.realpath(os.path.join(root, file_name)))
+        for root, dirs, _ in os.walk(folder, topdown=True):
+            for dir_name in dirs:
+                if dir_name.casefold() == target:
+                    return os.path.abspath(os.path.realpath(os.path.join(root, dir_name)))
+
     return None
 
 

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -1,0 +1,251 @@
+import json
+import os
+from typing import Optional
+
+
+_PIPELINE_CACHE = {}
+
+
+def is_zimage_checkpoint_name(name: str) -> bool:
+    lowered = (name or "").lower()
+    return "z-image" in lowered or "zimage" in lowered or "tongyi" in lowered
+
+
+def detect_zimage_flavor(name: str) -> str:
+    lowered = (name or "").lower()
+    if "turbo" in lowered:
+        return "turbo"
+    return "standard"
+
+
+def _read_json(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def is_zimage_model_directory(path: str) -> bool:
+    if not os.path.isdir(path):
+        return False
+
+    model_index_path = os.path.join(path, "model_index.json")
+    if os.path.isfile(model_index_path):
+        try:
+            model_index = _read_json(model_index_path)
+            class_name = str(model_index.get("_class_name", ""))
+            if "zimage" in class_name.lower():
+                return True
+            model_entries = str(model_index.get("transformer", ""))
+            if "zimage" in model_entries.lower():
+                return True
+        except Exception:
+            pass
+
+    transformer_config_path = os.path.join(path, "transformer", "config.json")
+    if os.path.isfile(transformer_config_path):
+        try:
+            transformer_config = _read_json(transformer_config_path)
+            class_name = str(transformer_config.get("_class_name", ""))
+            dim = int(transformer_config.get("dim", -1))
+            return "zimage" in class_name.lower() or dim == 3840
+        except Exception:
+            return False
+
+    return False
+
+
+def list_zimage_model_entries(checkpoint_folders: list[str]) -> list[str]:
+    entries = []
+    for folder in checkpoint_folders:
+        if not os.path.isdir(folder):
+            continue
+
+        for root, dirs, _ in os.walk(folder, topdown=True):
+            relative_root = os.path.relpath(root, folder)
+            relative_root = "" if relative_root == "." else relative_root
+
+            # Avoid traversing downloaded component folders inside a model directory.
+            if is_zimage_model_directory(root):
+                if relative_root:
+                    entries.append(relative_root)
+                dirs[:] = []
+                continue
+
+    return sorted(set(entries), key=str.casefold)
+
+
+def resolve_zimage_model_path(name: str, checkpoint_folders: list[str]) -> Optional[str]:
+    if not isinstance(name, str) or not name.strip():
+        return None
+
+    if os.path.isabs(name) and is_zimage_model_directory(name):
+        return name
+
+    for folder in checkpoint_folders:
+        candidate = os.path.abspath(os.path.realpath(os.path.join(folder, name)))
+        if is_zimage_model_directory(candidate):
+            return candidate
+
+    return None
+
+
+def _resolve_named_path(name: str, checkpoint_folders: list[str]) -> Optional[str]:
+    if not isinstance(name, str) or not name.strip():
+        return None
+
+    if os.path.isabs(name) and os.path.exists(name):
+        return os.path.abspath(os.path.realpath(name))
+
+    for folder in checkpoint_folders:
+        candidate = os.path.abspath(os.path.realpath(os.path.join(folder, name)))
+        if os.path.exists(candidate):
+            return candidate
+
+    return None
+
+
+def _is_likely_zimage_safetensors(path: str) -> bool:
+    if not os.path.isfile(path):
+        return False
+    if not path.lower().endswith(".safetensors"):
+        return False
+
+    try:
+        from safetensors import safe_open
+
+        with safe_open(path, framework="pt", device="cpu") as f:
+            keys = set(f.keys())
+
+            if any(k.startswith("text_encoders.qwen3_4b.") for k in keys):
+                return True
+
+            if "cap_embedder.1.weight" in keys:
+                cap_shape = tuple(f.get_tensor("cap_embedder.1.weight").shape)
+                if len(cap_shape) >= 1 and cap_shape[0] == 3840:
+                    return True
+
+            # Fallback fingerprint for NextDiT-like Z-Image layout.
+            has_lumina_backbone = any(k.startswith("layers.0.attention.") for k in keys)
+            has_zimage_text = any(k.startswith("text_encoders.") and "qwen3" in k for k in keys)
+            if has_lumina_backbone and has_zimage_text:
+                return True
+    except Exception:
+        return False
+
+    return False
+
+
+def should_use_zimage_checkpoint(name: str, checkpoint_folders: list[str]) -> bool:
+    if is_zimage_checkpoint_name(name):
+        return True
+
+    resolved = _resolve_named_path(name, checkpoint_folders)
+    if resolved is None:
+        return False
+
+    if os.path.isdir(resolved):
+        return is_zimage_model_directory(resolved)
+
+    return _is_likely_zimage_safetensors(resolved)
+
+
+def resolve_zimage_source(name: str, checkpoint_folders: list[str]) -> tuple[Optional[str], Optional[str], str]:
+    flavor = detect_zimage_flavor(name)
+    resolved = _resolve_named_path(name, checkpoint_folders)
+    if resolved is None:
+        return None, None, flavor
+
+    if os.path.isdir(resolved) and is_zimage_model_directory(resolved):
+        return "directory", resolved, flavor
+
+    if os.path.isfile(resolved) and _is_likely_zimage_safetensors(resolved):
+        return "single_file", resolved, flavor
+
+    return None, None, flavor
+
+
+def _repo_for_flavor(flavor: str) -> str:
+    if flavor == "turbo":
+        return "Tongyi-MAI/Z-Image-Turbo"
+    return "Tongyi-MAI/Z-Image"
+
+
+def _pick_device_and_dtype():
+    import torch
+
+    if torch.cuda.is_available():
+        if torch.cuda.is_bf16_supported():
+            return "cuda", torch.bfloat16
+        return "cuda", torch.float16
+    return "cpu", torch.float32
+
+
+def _load_pipeline(source_kind: str, source_path: str, flavor: str):
+    cache_key = f"{source_kind}:{os.path.abspath(source_path)}"
+    if cache_key in _PIPELINE_CACHE:
+        return _PIPELINE_CACHE[cache_key]
+
+    from diffusers import DiffusionPipeline
+
+    device, dtype = _pick_device_and_dtype()
+    if source_kind == "directory":
+        pipeline = DiffusionPipeline.from_pretrained(
+            source_path,
+            torch_dtype=dtype,
+            trust_remote_code=True,
+            local_files_only=False,
+        )
+    elif source_kind == "single_file":
+        pipeline = DiffusionPipeline.from_single_file(
+            source_path,
+            config=_repo_for_flavor(flavor),
+            torch_dtype=dtype,
+            trust_remote_code=True,
+            local_files_only=False,
+        )
+    else:
+        raise ValueError(f"Unsupported source kind: {source_kind}")
+
+    pipeline.set_progress_bar_config(disable=True)
+    pipeline.to(device)
+
+    _PIPELINE_CACHE[cache_key] = (pipeline, device)
+    return _PIPELINE_CACHE[cache_key]
+
+
+def generate_zimage(
+    source_kind: str,
+    source_path: str,
+    flavor: str,
+    prompt: str,
+    negative_prompt: str,
+    width: int,
+    height: int,
+    steps: int,
+    guidance_scale: float,
+    seed: int,
+):
+    import torch
+
+    pipeline, device = _load_pipeline(source_kind, source_path, flavor)
+    generator = torch.Generator(device=device).manual_seed(seed)
+
+    call_kwargs = dict(
+        prompt=prompt,
+        width=width,
+        height=height,
+        num_inference_steps=steps,
+        guidance_scale=guidance_scale,
+        generator=generator,
+        num_images_per_prompt=1,
+    )
+    if negative_prompt:
+        call_kwargs["negative_prompt"] = negative_prompt
+
+    try:
+        output = pipeline(**call_kwargs)
+    except TypeError:
+        call_kwargs.pop("negative_prompt", None)
+        output = pipeline(**call_kwargs)
+
+    image = output.images[0]
+    return image

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -5049,6 +5049,12 @@ def _generate_zimage_impl(
                         retry_sizes.append(pair)
 
         max_attempts = 4 if (flavor == "turbo" and allow_quality_fallback) else (2 if flavor == "turbo" else 3)
+        # Alternate path may need extra retries to walk:
+        # 1) latents on runtime device
+        # 2) latents on CPU
+        # 3) deep patcher disabled + non-deep offload
+        if _use_alt_path:
+            max_attempts = max(max_attempts, 4)
         for attempt in range(max_attempts):
             generation_attempts = attempt + 1
             try:

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -1,0 +1,275 @@
+import json
+import os
+from typing import Optional
+
+
+_PIPELINE_CACHE = {}
+
+
+def is_zimage_checkpoint_name(name: str) -> bool:
+    lowered = (name or "").lower()
+    return "z-image" in lowered or "zimage" in lowered or "tongyi" in lowered
+
+
+def detect_zimage_flavor(name: str) -> str:
+    lowered = (name or "").lower()
+    if "turbo" in lowered:
+        return "turbo"
+    return "standard"
+
+
+def _repo_for_flavor(flavor: str) -> str:
+    if flavor == "turbo":
+        return "Tongyi-MAI/Z-Image-Turbo"
+    return "Tongyi-MAI/Z-Image"
+
+
+def _read_json(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def is_zimage_model_directory(path: str) -> bool:
+    if not os.path.isdir(path):
+        return False
+
+    model_index_path = os.path.join(path, "model_index.json")
+    if os.path.isfile(model_index_path):
+        try:
+            model_index = _read_json(model_index_path)
+            class_name = str(model_index.get("_class_name", ""))
+            if "zimage" in class_name.lower():
+                return True
+            model_entries = str(model_index.get("transformer", ""))
+            if "zimage" in model_entries.lower():
+                return True
+        except Exception:
+            pass
+
+    transformer_config_path = os.path.join(path, "transformer", "config.json")
+    if os.path.isfile(transformer_config_path):
+        try:
+            transformer_config = _read_json(transformer_config_path)
+            class_name = str(transformer_config.get("_class_name", ""))
+            dim = int(transformer_config.get("dim", -1))
+            return "zimage" in class_name.lower() or dim == 3840
+        except Exception:
+            return False
+
+    return False
+
+
+def list_zimage_model_entries(checkpoint_folders: list[str]) -> list[str]:
+    entries = []
+    for folder in checkpoint_folders:
+        if not os.path.isdir(folder):
+            continue
+        for root, dirs, _ in os.walk(folder, topdown=True):
+            relative_root = os.path.relpath(root, folder)
+            relative_root = "" if relative_root == "." else relative_root
+            if is_zimage_model_directory(root):
+                if relative_root:
+                    entries.append(relative_root)
+                dirs[:] = []
+                continue
+    return sorted(set(entries), key=str.casefold)
+
+
+def _resolve_named_path(name: str, checkpoint_folders: list[str]) -> Optional[str]:
+    if not isinstance(name, str) or not name.strip():
+        return None
+
+    if os.path.isabs(name) and os.path.exists(name):
+        return os.path.abspath(os.path.realpath(name))
+
+    for folder in checkpoint_folders:
+        candidate = os.path.abspath(os.path.realpath(os.path.join(folder, name)))
+        if os.path.exists(candidate):
+            return candidate
+
+    return None
+
+
+def _is_likely_zimage_safetensors(path: str) -> bool:
+    if not os.path.isfile(path) or not path.lower().endswith(".safetensors"):
+        return False
+
+    try:
+        from safetensors import safe_open
+
+        with safe_open(path, framework="pt", device="cpu") as f:
+            keys = set(f.keys())
+            if any(k.startswith("text_encoders.qwen3_4b.") for k in keys):
+                return True
+            if "cap_embedder.1.weight" in keys:
+                shape = tuple(f.get_tensor("cap_embedder.1.weight").shape)
+                if len(shape) >= 1 and shape[0] == 3840:
+                    return True
+            if any(k.startswith("layers.0.attention.") for k in keys):
+                return True
+    except Exception:
+        return False
+
+    return False
+
+
+def should_use_zimage_checkpoint(name: str, checkpoint_folders: list[str]) -> bool:
+    if is_zimage_checkpoint_name(name):
+        return True
+
+    resolved = _resolve_named_path(name, checkpoint_folders)
+    if resolved is None:
+        return False
+
+    if os.path.isdir(resolved):
+        return is_zimage_model_directory(resolved)
+
+    return _is_likely_zimage_safetensors(resolved)
+
+
+def ensure_zimage_repo_download(flavor: str, checkpoint_folders: list[str]) -> str:
+    from huggingface_hub import snapshot_download
+
+    if not checkpoint_folders:
+        raise RuntimeError("No checkpoint folders configured.")
+
+    base_dir = os.path.abspath(checkpoint_folders[0])
+    repo_id = _repo_for_flavor(flavor)
+    relative = repo_id.replace("/", os.sep)
+    local_dir = os.path.join(base_dir, relative)
+    os.makedirs(local_dir, exist_ok=True)
+
+    # If already present and valid, skip network.
+    if is_zimage_model_directory(local_dir):
+        return local_dir
+
+    snapshot_download(
+        repo_id=repo_id,
+        local_dir=local_dir,
+        local_dir_use_symlinks=False,
+        allow_patterns=[
+            "model_index.json",
+            "transformer/*",
+            "text_encoder/*",
+            "tokenizer/*",
+            "vae/*",
+            "scheduler/*",
+        ],
+    )
+
+    if not is_zimage_model_directory(local_dir):
+        raise RuntimeError(f"Downloaded {repo_id}, but model layout is incomplete at: {local_dir}")
+    return local_dir
+
+
+def resolve_zimage_source(name: str, checkpoint_folders: list[str], auto_download_if_missing: bool = True) -> tuple[Optional[str], Optional[str], str]:
+    flavor = detect_zimage_flavor(name)
+    resolved = _resolve_named_path(name, checkpoint_folders)
+
+    if resolved is not None:
+        if os.path.isdir(resolved) and is_zimage_model_directory(resolved):
+            return "directory", resolved, flavor
+        if os.path.isfile(resolved) and _is_likely_zimage_safetensors(resolved):
+            return "single_file", resolved, flavor
+
+    if auto_download_if_missing and is_zimage_checkpoint_name(name):
+        downloaded = ensure_zimage_repo_download(flavor, checkpoint_folders)
+        return "directory", downloaded, flavor
+
+    return None, None, flavor
+
+
+def _pick_device_and_dtype():
+    import torch
+
+    if torch.cuda.is_available():
+        if torch.cuda.is_bf16_supported():
+            return "cuda", torch.bfloat16
+        return "cuda", torch.float16
+    return "cpu", torch.float32
+
+
+def _load_pipeline(source_kind: str, source_path: str, flavor: str, checkpoint_folders: list[str]):
+    cache_key = f"{source_kind}:{os.path.abspath(source_path)}"
+    if cache_key in _PIPELINE_CACHE:
+        return _PIPELINE_CACHE[cache_key]
+
+    from diffusers import DiffusionPipeline
+
+    device, dtype = _pick_device_and_dtype()
+
+    if source_kind == "directory":
+        pipeline = DiffusionPipeline.from_pretrained(
+            source_path,
+            torch_dtype=dtype,
+            trust_remote_code=True,
+            local_files_only=False,
+        )
+    elif source_kind == "single_file":
+        # Some diffusers builds do not support single-file loading for custom pipelines.
+        if hasattr(DiffusionPipeline, "from_single_file"):
+            pipeline = DiffusionPipeline.from_single_file(
+                source_path,
+                config=_repo_for_flavor(flavor),
+                torch_dtype=dtype,
+                trust_remote_code=True,
+                local_files_only=False,
+            )
+        else:
+            # Universal fallback: download/load official repo layout.
+            fallback_dir = ensure_zimage_repo_download(flavor, checkpoint_folders)
+            pipeline = DiffusionPipeline.from_pretrained(
+                fallback_dir,
+                torch_dtype=dtype,
+                trust_remote_code=True,
+                local_files_only=False,
+            )
+            source_kind = "directory"
+            source_path = fallback_dir
+            cache_key = f"{source_kind}:{os.path.abspath(source_path)}"
+    else:
+        raise ValueError(f"Unsupported source kind: {source_kind}")
+
+    pipeline.set_progress_bar_config(disable=True)
+    pipeline.to(device)
+    _PIPELINE_CACHE[cache_key] = (pipeline, device)
+    return _PIPELINE_CACHE[cache_key]
+
+
+def generate_zimage(
+    source_kind: str,
+    source_path: str,
+    flavor: str,
+    checkpoint_folders: list[str],
+    prompt: str,
+    negative_prompt: str,
+    width: int,
+    height: int,
+    steps: int,
+    guidance_scale: float,
+    seed: int,
+):
+    import torch
+
+    pipeline, device = _load_pipeline(source_kind, source_path, flavor, checkpoint_folders)
+    generator = torch.Generator(device=device).manual_seed(seed)
+
+    call_kwargs = dict(
+        prompt=prompt,
+        width=width,
+        height=height,
+        num_inference_steps=steps,
+        guidance_scale=guidance_scale,
+        generator=generator,
+        num_images_per_prompt=1,
+    )
+    if negative_prompt:
+        call_kwargs["negative_prompt"] = negative_prompt
+
+    try:
+        output = pipeline(**call_kwargs)
+    except TypeError:
+        call_kwargs.pop("negative_prompt", None)
+        output = pipeline(**call_kwargs)
+
+    return output.images[0]

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -3955,7 +3955,8 @@ def generate_zimage(
     except Exception:
         pass
 
-    max_sequence_length = 256 if flavor == "turbo" else 512
+    # Keep turbo aligned with Z-Image pipeline defaults instead of a stricter local cap.
+    max_sequence_length = 512
     use_cfg = guidance_scale > 1.0
     allow_quality_fallback = _zimage_allow_quality_fallback()
 

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -1092,12 +1092,12 @@ def _zimage_attention_backend_candidates(mode: str, allow_xformers: bool = True)
     if mode == "sdpa":
         return ["flash_attention_2", "flash_attention", "sdpa", "native"]
     if mode == "flash":
-        return ["flash_attention_2", "flash_attention", "flash", "sdpa", "native"]
+        return ["flash", "flash_attention_2", "flash_attention", "sdpa", "native"]
     if mode == "xformers":
         return ["xformers", "native"]
 
     # auto
-    candidates = ["flash_attention_2", "flash_attention", "flash", "sdpa"]
+    candidates = ["flash", "flash_attention_2", "flash_attention", "sdpa"]
     if allow_xformers:
         candidates.append("xformers")
     candidates.append("native")

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -1358,7 +1358,7 @@ def generate_zimage(
     steps: int,
     guidance_scale: float,
     seed: int,
-    shift: float = 9.0,
+    shift: float = 3.0,
 ):
     import torch
 

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -73,7 +73,7 @@ def _zimage_perf_profile() -> str:
 
 
 def _zimage_xformers_mode() -> str:
-    value = os.environ.get("FOOOCUS_ZIMAGE_XFORMERS", "auto").strip().lower()
+    value = os.environ.get("FOOOCUS_ZIMAGE_XFORMERS", "on").strip().lower()
     if value in ("1", "true", "yes", "on", "force"):
         return "on"
     if value in ("0", "false", "no", "off", "disable"):

--- a/modules/zimage_poc.py
+++ b/modules/zimage_poc.py
@@ -40,16 +40,6 @@ def _pipeline_cache_key(
     return f"{source_kind}:{os.path.abspath(source_path)}:te={te}:vae={vae}"
 
 
-def _override_cache_token(value: Optional[str]) -> str:
-    if not value:
-        return "-"
-    return os.path.abspath(os.path.realpath(value))
-
-
-def _zimage_yolo_model_swap_enabled() -> bool:
-    return _truthy_env("FOOOCUS_ZIMAGE_YOLO_MODEL_SWAP", "1")
-
-
 def _single_file_identity(path: str) -> str:
     abspath = os.path.abspath(path)
     try:
@@ -275,17 +265,6 @@ def _drop_cache_entry(cache_key: str) -> None:
     _clear_prompt_cache_for_pipeline(cache_key)
 
 
-def _drop_cache_aliases_for_pipeline(target_pipeline) -> None:
-    stale_keys = []
-    for key, cached in list(_PIPELINE_CACHE.items()):
-        if not isinstance(cached, tuple) or len(cached) < 1:
-            continue
-        if cached[0] is target_pipeline:
-            stale_keys.append(key)
-    for key in stale_keys:
-        _drop_cache_entry(key)
-
-
 def _cleanup_memory(cuda: bool = True, aggressive: bool = True) -> None:
     if aggressive:
         gc.collect()
@@ -390,15 +369,6 @@ def maybe_cleanup_for_model_change(source_kind: Optional[str], source_path: Opti
     changed = previous_signature is not None and previous_signature != signature
     if not changed:
         return {"changed": False, "cleaned": False, "pipelines": 0, "prompt_cache_entries": 0}
-
-    if source_kind == "single_file" and _zimage_yolo_model_swap_enabled():
-        prev_name = os.path.basename(previous_signature[1]) if previous_signature else "unknown"
-        next_name = os.path.basename(signature[1])
-        print(
-            "[Z-Image POC] Model source changed; deferring harsh cleanup "
-            f"({prev_name} -> {next_name}) because YOLO model swap is enabled."
-        )
-        return {"changed": True, "cleaned": False, "pipelines": 0, "prompt_cache_entries": 0}
 
     if not _zimage_harsh_cleanup_on_model_change_enabled():
         return {"changed": True, "cleaned": False, "pipelines": 0, "prompt_cache_entries": 0}
@@ -3784,8 +3754,6 @@ def _load_pipeline(
     text_encoder_override: Optional[str] = None,
     vae_override: Optional[str] = None,
 ):
-    text_override_token = _override_cache_token(text_encoder_override)
-    vae_override_token = _override_cache_token(vae_override)
     cache_key = _pipeline_cache_key(
         source_kind,
         source_path,
@@ -3827,62 +3795,6 @@ def _load_pipeline(
 
     zimage_allow_fp16 = _detect_zimage_allow_fp16(source_kind, source_path)
     device, dtype = _pick_device_and_dtype(zimage_allow_fp16=zimage_allow_fp16)
-
-    if source_kind == "single_file" and _zimage_yolo_model_swap_enabled():
-        reusable = None
-        for candidate_key, cached in list(_PIPELINE_CACHE.items()):
-            if not isinstance(cached, tuple) or len(cached) < 1:
-                continue
-            candidate_pipeline = cached[0]
-            if candidate_pipeline is None or _pipeline_has_meta_tensors(candidate_pipeline):
-                continue
-            if getattr(candidate_pipeline, "_zimage_cache_source_kind", None) != "single_file":
-                continue
-            if getattr(candidate_pipeline, "_zimage_cache_text_override_token", "-") != text_override_token:
-                continue
-            if getattr(candidate_pipeline, "_zimage_cache_vae_override_token", "-") != vae_override_token:
-                continue
-            if getattr(candidate_pipeline, "_zimage_cache_flavor", flavor) != flavor:
-                continue
-            candidate_source = str(getattr(candidate_pipeline, "_zimage_cache_source_path", ""))
-            if candidate_source and os.path.abspath(candidate_source) == os.path.abspath(source_path):
-                continue
-            reusable = (candidate_key, candidate_pipeline)
-            break
-
-        if reusable is not None:
-            _, reusable_pipeline = reusable
-            from_name = os.path.basename(str(getattr(reusable_pipeline, "_zimage_cache_source_path", "unknown")))
-            to_name = os.path.basename(source_path)
-            print(
-                f"[Z-Image POC] YOLO model swap: reusing existing pipeline "
-                f"({from_name} -> {to_name}) and replacing transformer weights."
-            )
-            try:
-                _load_transformer_weights_from_single_file(source_path, reusable_pipeline)
-                if _pipeline_has_meta_tensors(reusable_pipeline):
-                    raise RuntimeError("YOLO swapped pipeline contains meta tensors")
-                if text_encoder_override is not None:
-                    _load_component_override(reusable_pipeline, "text_encoder", text_encoder_override, dtype)
-                if vae_override is not None:
-                    _load_component_override(reusable_pipeline, "vae", vae_override, dtype)
-                generator_device, used_offload = _prepare_pipeline_memory_mode(reusable_pipeline, device)
-                _maybe_prewarm_pipeline(reusable_pipeline, generator_device=generator_device, flavor=flavor)
-                _drop_cache_aliases_for_pipeline(reusable_pipeline)
-                reusable_pipeline._zimage_cache_source_kind = source_kind
-                reusable_pipeline._zimage_cache_source_path = os.path.abspath(source_path)
-                reusable_pipeline._zimage_cache_flavor = flavor
-                reusable_pipeline._zimage_cache_text_override_token = text_override_token
-                reusable_pipeline._zimage_cache_vae_override_token = vae_override_token
-                _PIPELINE_CACHE[cache_key] = (reusable_pipeline, generator_device, used_offload)
-                return _PIPELINE_CACHE[cache_key]
-            except Exception as e:
-                print(f"[Z-Image POC] YOLO model swap failed, falling back to full rebuild: {e}")
-                try:
-                    _drop_cache_aliases_for_pipeline(reusable_pipeline)
-                except Exception:
-                    pass
-                _cleanup_memory(cuda=True, aggressive=True)
 
     if source_kind == "directory":
         pipeline = _call_with_dtype_compat(
@@ -4002,11 +3914,6 @@ def _load_pipeline(
     pipeline.set_progress_bar_config(disable=True)
     generator_device, used_offload = _prepare_pipeline_memory_mode(pipeline, device)
     _maybe_prewarm_pipeline(pipeline, generator_device=generator_device, flavor=flavor)
-    pipeline._zimage_cache_source_kind = source_kind
-    pipeline._zimage_cache_source_path = os.path.abspath(source_path)
-    pipeline._zimage_cache_flavor = flavor
-    pipeline._zimage_cache_text_override_token = text_override_token
-    pipeline._zimage_cache_vae_override_token = vae_override_token
     _PIPELINE_CACHE[cache_key] = (pipeline, generator_device, used_offload)
     return _PIPELINE_CACHE[cache_key]
 

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ After downloading, extract and run `run.bat`.
 
 - **Minimum:** 4GB Nvidia GPU VRAM and 8GB system RAM
 - **Recommended:** 6GB+ VRAM and 16GB+ RAM
-- **Runtime dependencies:** install from `requirements_versions.txt` (includes pinned `xformers` for consistent Z-Image acceleration behavior)
+- **Runtime dependencies:** install from `requirements_versions.txt` (Z-Image stack is pinned there; `xformers` remains optional acceleration)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,7 @@ After downloading, extract and run `run.bat`.
 
 - **Minimum:** 4GB Nvidia GPU VRAM and 8GB system RAM
 - **Recommended:** 6GB+ VRAM and 16GB+ RAM
+- **Runtime dependencies:** install from `requirements_versions.txt` (includes pinned `xformers` for consistent Z-Image acceleration behavior)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -81,17 +81,6 @@ When disabled, wildcard entries are chosen randomly.
 
 ---
 
-## Model Folder Conventions
-
-Custom text encoders are supported.
-
-- Place custom text encoder files/folders under `models/text_encoders/`
-- Recommended for Z-Image/Qwen-style encoders (example filename: `qwen3_4b_fp8_scaled.safetensors`)
-
-`models/text_encoders/` is included as an empty folder by default so clean installs have the expected location.
-
----
-
 ## Download
 
 ### Windows

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,17 @@ When disabled, wildcard entries are chosen randomly.
 
 ---
 
+## Model Folder Conventions
+
+Custom text encoders are supported.
+
+- Place custom text encoder files/folders under `models/text_encoders/`
+- Recommended for Z-Image/Qwen-style encoders (example filename: `qwen3_4b_fp8_scaled.safetensors`)
+
+`models/text_encoders/` is included as an empty folder by default so clean installs have the expected location.
+
+---
+
 ## Download
 
 ### Windows

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,2 +1,3 @@
 torch==2.1.0
 torchvision==0.16.0
+diffusers==0.30.3

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,3 +1,3 @@
 torch==2.1.0
 torchvision==0.16.0
-diffusers==0.30.3
+diffusers==0.31.0

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,4 +1,3 @@
-torch==2.1.0
-torchvision==0.16.0
+torch==2.5.1
+torchvision==0.20.1
 diffusers==0.36.0
-xformers==0.0.23

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,3 +1,3 @@
-torch==2.9.0
-torchvision==0.24.0
+torch==2.9.1
+torchvision==0.24.1
 diffusers==0.36.0

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,3 +1,3 @@
-torch==2.6.0
-torchvision==0.21.0
+torch==2.9.0
+torchvision==0.24.0
 diffusers==0.36.0

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,3 +1,4 @@
 torch==2.1.0
 torchvision==0.16.0
 diffusers==0.36.0
+xformers==0.0.23

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,2 +1,3 @@
 torch==2.1.0
 torchvision==0.16.0
+diffusers==0.31.0

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,3 +1,3 @@
 torch==2.1.0
 torchvision==0.16.0
-diffusers==0.31.0
+diffusers==0.36.0

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,3 +1,3 @@
-torch==2.5.1
-torchvision==0.20.1
+torch==2.6.0
+torchvision==0.21.0
 diffusers==0.36.0

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -23,3 +23,4 @@ packaging==24.1
 rembg==2.0.57
 groundingdino-py==0.4.0
 segment_anything==1.0
+xformers==0.0.23

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,6 +1,7 @@
 torchsde==0.2.6
 einops==0.8.0
 transformers==4.42.4
+diffusers==0.31.0
 safetensors==0.4.3
 accelerate==0.32.1
 pyyaml==6.0.1

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -23,4 +23,3 @@ packaging==24.1
 rembg==2.0.57
 groundingdino-py==0.4.0
 segment_anything==1.0
-xformers==0.0.23

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,9 +1,9 @@
 torchsde==0.2.6
 einops==0.8.0
-transformers==4.42.4
-diffusers==0.31.0
-safetensors==0.4.3
-accelerate==0.32.1
+transformers==4.56.2
+diffusers==0.36.0
+safetensors==0.7.0
+accelerate==1.12.0
 pyyaml==6.0.1
 pillow==10.4.0
 scipy==1.14.0
@@ -18,7 +18,7 @@ httpx==0.27.0
 onnxruntime==1.18.1
 timm==1.0.7
 numpy==1.26.4
-tokenizers==0.19.1
+tokenizers==0.22.1
 packaging==24.1
 rembg==2.0.57
 groundingdino-py==0.4.0

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,7 +1,7 @@
 torchsde==0.2.6
 einops==0.8.0
 transformers==4.42.4
-diffusers==0.30.3
+diffusers==0.31.0
 safetensors==0.4.3
 accelerate==0.32.1
 pyyaml==6.0.1

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,6 +1,7 @@
 torchsde==0.2.6
 einops==0.8.0
 transformers==4.42.4
+diffusers==0.30.3
 safetensors==0.4.3
 accelerate==0.32.1
 pyyaml==6.0.1

--- a/tests/test_zimage_alt_path.py
+++ b/tests/test_zimage_alt_path.py
@@ -77,6 +77,12 @@ class TestZImageAltPath(unittest.TestCase):
         alt_mock.assert_called_once()
         legacy_mock.assert_not_called()
 
+    def test_alt_force_full_gpu_default_is_enabled(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(zimage_poc._zimage_alt_force_full_gpu_enabled())
+        with mock.patch.dict(os.environ, {"FOOOCUS_ZIMAGE_ALT_FORCE_FULL_GPU": "0"}, clear=False):
+            self.assertFalse(zimage_poc._zimage_alt_force_full_gpu_enabled())
+
     def test_alt_path_rejects_pipeline_without_latents_kwarg(self):
         pipeline = _DummyPipelineWithoutLatents()
         with self.assertRaisesRegex(RuntimeError, "latents support"):

--- a/tests/test_zimage_alt_path.py
+++ b/tests/test_zimage_alt_path.py
@@ -1,0 +1,131 @@
+import os
+import unittest
+from unittest import mock
+
+import torch
+
+from modules import zimage_poc
+
+
+class _DummyTransformer:
+    def __init__(self):
+        self.dtype = torch.float32
+        self.config = type("cfg", (), {"in_channels": 4})()
+
+
+class _DummyPipelineWithLatents:
+    def __init__(self):
+        self.transformer = _DummyTransformer()
+        self.vae_scale_factor = 8
+
+    def __call__(self, *, latents=None, **kwargs):
+        return latents, kwargs
+
+
+class _DummyPipelineWithoutLatents:
+    def __init__(self):
+        self.transformer = _DummyTransformer()
+        self.vae_scale_factor = 8
+
+    def __call__(self, *, prompt=None, **kwargs):
+        return prompt, kwargs
+
+
+class TestZImageAltPath(unittest.TestCase):
+    def _base_kwargs(self):
+        return dict(
+            source_kind="single_file",
+            source_path="/tmp/dummy.safetensors",
+            flavor="turbo",
+            checkpoint_folders=[],
+            prompt="p",
+            negative_prompt="",
+            width=832,
+            height=1216,
+            steps=9,
+            guidance_scale=1.0,
+            seed=1234,
+        )
+
+    def test_dispatch_routes_to_alternate_when_enabled(self):
+        kwargs = self._base_kwargs()
+        with mock.patch.dict(os.environ, {"FOOOCUS_ZIMAGE_ALT_PATH": "1"}, clear=False):
+            with mock.patch("modules.zimage_poc._generate_zimage_alt", return_value="alt") as alt_mock:
+                with mock.patch("modules.zimage_poc._generate_zimage_legacy", return_value="legacy") as legacy_mock:
+                    result = zimage_poc.generate_zimage(**kwargs)
+        self.assertEqual("alt", result)
+        alt_mock.assert_called_once()
+        legacy_mock.assert_not_called()
+
+    def test_dispatch_routes_to_legacy_when_disabled(self):
+        kwargs = self._base_kwargs()
+        with mock.patch.dict(os.environ, {"FOOOCUS_ZIMAGE_ALT_PATH": "0"}, clear=False):
+            with mock.patch("modules.zimage_poc._generate_zimage_alt", return_value="alt") as alt_mock:
+                with mock.patch("modules.zimage_poc._generate_zimage_legacy", return_value="legacy") as legacy_mock:
+                    result = zimage_poc.generate_zimage(**kwargs)
+        self.assertEqual("legacy", result)
+        legacy_mock.assert_called_once()
+        alt_mock.assert_not_called()
+
+    def test_dispatch_defaults_to_alternate_when_env_unset(self):
+        kwargs = self._base_kwargs()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch("modules.zimage_poc._generate_zimage_alt", return_value="alt") as alt_mock:
+                with mock.patch("modules.zimage_poc._generate_zimage_legacy", return_value="legacy") as legacy_mock:
+                    result = zimage_poc.generate_zimage(**kwargs)
+        self.assertEqual("alt", result)
+        alt_mock.assert_called_once()
+        legacy_mock.assert_not_called()
+
+    def test_alt_path_rejects_pipeline_without_latents_kwarg(self):
+        pipeline = _DummyPipelineWithoutLatents()
+        with self.assertRaisesRegex(RuntimeError, "latents support"):
+            zimage_poc._ensure_alt_path_prerequisites(pipeline, width=832, height=1216)
+
+    def test_latents_are_deterministic_for_same_seeds(self):
+        pipeline = _DummyPipelineWithLatents()
+        latents_a = zimage_poc._build_latents_from_seeds(
+            pipeline=pipeline,
+            seed_list=[101, 202],
+            width=832,
+            height=1216,
+            generator_device="cpu",
+        )
+        latents_b = zimage_poc._build_latents_from_seeds(
+            pipeline=pipeline,
+            seed_list=[101, 202],
+            width=832,
+            height=1216,
+            generator_device="cpu",
+        )
+        latents_c = zimage_poc._build_latents_from_seeds(
+            pipeline=pipeline,
+            seed_list=[303, 202],
+            width=832,
+            height=1216,
+            generator_device="cpu",
+        )
+        self.assertTrue(torch.equal(latents_a, latents_b))
+        self.assertFalse(torch.equal(latents_a, latents_c))
+
+    def test_alt_path_random_source_uses_latents_not_generator(self):
+        pipeline = _DummyPipelineWithLatents()
+        call_kwargs = {
+            "width": 832,
+            "height": 1216,
+            "generator": object(),
+        }
+        zimage_poc._set_generation_random_source(
+            call_kwargs=call_kwargs,
+            seed_list=[7, 11],
+            pipeline=pipeline,
+            generator_device="cpu",
+            use_alt_path=True,
+        )
+        self.assertNotIn("generator", call_kwargs)
+        self.assertIn("latents", call_kwargs)
+        self.assertEqual(2, int(call_kwargs["latents"].shape[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zimage_alt_path.py
+++ b/tests/test_zimage_alt_path.py
@@ -89,6 +89,16 @@ class TestZImageAltPath(unittest.TestCase):
         with mock.patch.dict(os.environ, {"FOOOCUS_ZIMAGE_ALT_LATENT_SOURCE": "cpu"}, clear=False):
             self.assertEqual("cpu", zimage_poc._zimage_alt_latent_source_mode())
 
+    def test_flash_backend_candidates_prioritize_flash(self):
+        candidates = zimage_poc._zimage_attention_backend_candidates("flash", allow_xformers=True)
+        self.assertGreaterEqual(len(candidates), 1)
+        self.assertEqual("flash", candidates[0])
+
+    def test_auto_backend_candidates_prioritize_flash(self):
+        candidates = zimage_poc._zimage_attention_backend_candidates("auto", allow_xformers=True)
+        self.assertGreaterEqual(len(candidates), 1)
+        self.assertEqual("flash", candidates[0])
+
     def test_alt_path_rejects_pipeline_without_latents_kwarg(self):
         pipeline = _DummyPipelineWithoutLatents()
         with self.assertRaisesRegex(RuntimeError, "latents support"):

--- a/webui.py
+++ b/webui.py
@@ -117,15 +117,6 @@ def sort_enhance_images(images, task):
 def _zit_component_selector_updates(base_model_name, text_encoder_selection, vae_selection):
     auto_choice = modules.zimage_poc.ZIMAGE_COMPONENT_AUTO
 
-    def _choice_values(choices):
-        values = []
-        for choice in choices:
-            if isinstance(choice, (tuple, list)) and len(choice) >= 2:
-                values.append(choice[1])
-            else:
-                values.append(choice)
-        return values
-
     try:
         is_zit, detection_reason = modules.zimage_poc.inspect_zimage_checkpoint_detection(
             base_model_name, modules.config.paths_checkpoints
@@ -134,21 +125,19 @@ def _zit_component_selector_updates(base_model_name, text_encoder_selection, vae
         is_zit = False
         detection_reason = f"detection error: {e}"
 
-    text_encoder_choices = [(auto_choice, auto_choice)]
-    vae_choices = [(auto_choice, auto_choice)]
+    text_encoder_choices = [auto_choice]
+    vae_choices = [auto_choice]
     if is_zit:
         text_encoder_choices += modules.zimage_poc.list_zimage_component_choices(
             "text_encoder", modules.config.paths_checkpoints
         )
         vae_choices += modules.zimage_poc.list_zimage_component_choices("vae", modules.config.paths_checkpoints)
 
-    text_encoder_values = _choice_values(text_encoder_choices)
-    vae_values = _choice_values(vae_choices)
-    text_encoder_value = text_encoder_selection if text_encoder_selection in text_encoder_values else auto_choice
-    vae_value = vae_selection if vae_selection in vae_values else auto_choice
+    text_encoder_value = text_encoder_selection if text_encoder_selection in text_encoder_choices else auto_choice
+    vae_value = vae_selection if vae_selection in vae_choices else auto_choice
     status_text = (
         f"ZIT detection: {'YES' if is_zit else 'NO'} | base model: `{base_model_name}` | "
-        f"{detection_reason} | text encoders: {max(0, len(text_encoder_values) - 1)} | vaes: {max(0, len(vae_values) - 1)}"
+        f"{detection_reason} | text encoders: {max(0, len(text_encoder_choices) - 1)} | vaes: {max(0, len(vae_choices) - 1)}"
     )
     print(f"[ZIT UI] {status_text}")
     return (

--- a/webui.py
+++ b/webui.py
@@ -116,6 +116,16 @@ def sort_enhance_images(images, task):
 
 def _zit_component_selector_updates(base_model_name, text_encoder_selection, vae_selection):
     auto_choice = modules.zimage_poc.ZIMAGE_COMPONENT_AUTO
+
+    def _choice_values(choices):
+        values = []
+        for choice in choices:
+            if isinstance(choice, (tuple, list)) and len(choice) >= 2:
+                values.append(choice[1])
+            else:
+                values.append(choice)
+        return values
+
     try:
         is_zit, detection_reason = modules.zimage_poc.inspect_zimage_checkpoint_detection(
             base_model_name, modules.config.paths_checkpoints
@@ -124,19 +134,21 @@ def _zit_component_selector_updates(base_model_name, text_encoder_selection, vae
         is_zit = False
         detection_reason = f"detection error: {e}"
 
-    text_encoder_choices = [auto_choice]
-    vae_choices = [auto_choice]
+    text_encoder_choices = [(auto_choice, auto_choice)]
+    vae_choices = [(auto_choice, auto_choice)]
     if is_zit:
-        text_encoder_choices += modules.zimage_poc.list_zimage_component_entries(
+        text_encoder_choices += modules.zimage_poc.list_zimage_component_choices(
             "text_encoder", modules.config.paths_checkpoints
         )
-        vae_choices += modules.zimage_poc.list_zimage_component_entries("vae", modules.config.paths_checkpoints)
+        vae_choices += modules.zimage_poc.list_zimage_component_choices("vae", modules.config.paths_checkpoints)
 
-    text_encoder_value = text_encoder_selection if text_encoder_selection in text_encoder_choices else auto_choice
-    vae_value = vae_selection if vae_selection in vae_choices else auto_choice
+    text_encoder_values = _choice_values(text_encoder_choices)
+    vae_values = _choice_values(vae_choices)
+    text_encoder_value = text_encoder_selection if text_encoder_selection in text_encoder_values else auto_choice
+    vae_value = vae_selection if vae_selection in vae_values else auto_choice
     status_text = (
         f"ZIT detection: {'YES' if is_zit else 'NO'} | base model: `{base_model_name}` | "
-        f"{detection_reason} | text encoders: {max(0, len(text_encoder_choices) - 1)} | vaes: {max(0, len(vae_choices) - 1)}"
+        f"{detection_reason} | text encoders: {max(0, len(text_encoder_values) - 1)} | vaes: {max(0, len(vae_values) - 1)}"
     )
     print(f"[ZIT UI] {status_text}")
     return (


### PR DESCRIPTION
## Summary
- add a dedicated Z-Image runtime path with model discovery, source resolution, component overrides, backend selection, cache management, and alternate latent-driven generation
- route detected Z-Image checkpoints through the async worker with Turbo defaults, batching, retry fallback behavior, and UI selectors for text encoder / VAE overrides
- harden launcher and dependency setup by pinning the newer torch/diffusers/transformers stack, auto-mapping xformers, optionally installing flash-attn, and failing open when expansion dependencies are unavailable

## Testing
- python -m unittest tests.test_zimage_alt_path